### PR TITLE
Suggest Drupal for instances of Drupal 8

### DIFF
--- a/styles/base/replacements.yml
+++ b/styles/base/replacements.yml
@@ -11,6 +11,7 @@ swap:
   "D7": "Drupal 7"
   "D8": "Drupal 8"
   "D9": "Drupal 9"
+  "Drupal 8": "Drupal"
   "Developer": "developer"
   "[Dd]rupalize.me": "Drupalize.Me"
   "[Dd]rupal[ -][Cc]onsole": "Drupal Console"


### PR DESCRIPTION
Resolves #15 

I believe this change will throw a warning and suggest using "Drupal" when it finds "Drupal 8".