### PR TITLE
Add a readability check to Vale linter

### DIFF
--- a/styles/base/readability.yml
+++ b/styles/base/readability.yml
@@ -1,0 +1,7 @@
+extends: readability
+message: "Grade level (%s), based on length of words and sentences. Edit for clear and concise language."
+level: warning
+grade: 9
+metrics:
+  - Flesch-Kincaid
+  - Automated Readability

--- a/styles/base/replacements.yml
+++ b/styles/base/replacements.yml
@@ -26,7 +26,7 @@ swap:
   "meta[ -]data": "metadata"
   "{MODULENAME}.": "MODULENAME."
   # Adding the leading space ensures we don't trip up on things like gatsby-node.js.
-  "[\s]node[.]?js": Node.js
+  "node[.]?js": Node.js
   "non-profit": "nonprofit"
   "of core": "of Drupal core"
   "off[ -]site": "offsite"


### PR DESCRIPTION
- Create readability.yml to /styles directory.

This tutorial should produce a warning:

- /configuration_management/how-override-configuration.md

This tutorial should pass:

- /dr-projects/movie/movieproject07.md

Readability scores from 2019 can be found here:
https://docs.google.com/spreadsheets/d/1F_OMp71cQnEr6VZ_G4rnlAqB0QL7wGdhpe2W1Hkc6tw/edit#gid=0

