### PR TITLE
Configure list-item-spacing rule

### DIFF
--- a/.remarkrc.yml
+++ b/.remarkrc.yml
@@ -17,6 +17,9 @@ plugins:
   remark-lint-emphasis-marker: '_'
   remark-validate-links:
   remark-lint-no-dead-urls:
+  # We often have complex and long lists. This allows for tight and loose lists.
+  # @see https://github.com/remarkjs/remark-lint/tree/main/packages/remark-lint-list-item-spacing#recommendation
+  remark-lint-list-item-spacing: true, {checkBlanks: true}
 
 # These settings are used when you use remark to output formatted Markdown.
 settings:


### PR DESCRIPTION
This is my attempt to configure remark-lint-list-item-spacing so that it will detect both "tight" and "loose" lists, in an attempt to get our more complex lists to pass the linter.

I couldn't figure out how to test this in the CLI, so I have no idea if this will work.

See https://github.com/remarkjs/remark-lint/tree/main/packages/remark-lint-list-item-spacing#recommendation