### PR TITLE
Fix invalid value 'code' in ui-interactions.yml

### DIFF
--- a/styles/base/ui-interactions.yml
+++ b/styles/base/ui-interactions.yml
@@ -2,7 +2,7 @@ extends: existence
 message: Consider replacing '%s' with a non device-specific action.
 link: https://docs.microsoft.com/en-us/style-guide/procedures-instructions/describing-interactions-with-ui
 level: warning
-code: false
+scope: text
 ignorecase: true
 tokens:
   - click


### PR DESCRIPTION
When running vale on a tutorial, I got an error that "code" was an invalid key in styles/base/ui-interactions.yml. Reading through the Vale docs on the "existence" plugin, I saw that the proper syntax is to use the key "scope" with a value of "text" when you only want to check text and not code blocks. See https://vale.sh/docs/topics/styles/

```
amber@Ambers-MBP ~/S/tutorials (routing-101) [1]> npm run review tutorials/module_dev_basics/routing/routing-overview.md 

> drupalizeme_tutorials@1.0.0 review
> vale --no-wrap --config='./node_modules/osiolabs-copyeditor/.vale.ini' tutorials/module_dev_basics/routing/routing-overview.md

E201 Invalid value [node_modules/osiolabs-copyeditor/styles/base/ui-interactions.yml:5:1]:

   4  level: warning
   5* code: false
   6  ignorecase: true
   7  tokens:

has invalid keys: 'code'

```